### PR TITLE
Refactor to add EU868 support and prepare for others

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=MCCI Arduino LoRaWAN library
-version=0.2.2
+version=0.2.3
 author=MCCI Corporation
 maintainer=Terry Moore <tmm@mcci.com>
 sentence=High-level library for LoRaWAN-based Arduino end-devices
-paragraph=Implements many of the details of network interfacing and deployment, so that you can focus on your application rather than worrying about the network. Requires the arduino-lmic library from The Things Network NY. 
+paragraph=Implements many of the details of network interfacing and deployment, so that you can focus on your application rather than worrying about the network. Requires the arduino-lmic library from The Things Network NY.
 category=Communication
 url=https://github.com/terrillmoore/arduino-lorawan/
 architectures=*

--- a/src/Arduino_LoRaWAN_ttn.h
+++ b/src/Arduino_LoRaWAN_ttn.h
@@ -1,4 +1,4 @@
-/* Arduino_LoRaWAN_ttn.h	Mon Oct 31 2016 15:44:49 tmm */
+/* Arduino_LoRaWAN_ttn.h	Fri May 19 2017 23:58:34 tmm */
 
 /*
 
@@ -8,26 +8,29 @@ Function:
 	LoRaWAN-variants for The Things Network.
 
 Version:
-	V0.2.0	Mon Oct 31 2016 15:44:49 tmm	Edit level 1
+	V0.2.3	Fri May 19 2017 23:58:34 tmm	Edit level 2
 
 Copyright notice:
-	This file copyright (C) 2016 by
+	This file copyright (C) 2016-2017 by
 
 		MCCI Corporation
 		3520 Krums Corners Road
 		Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	October 2016
 
 Revision history:
    0.2.0  Mon Oct 31 2016 15:44:49  tmm
 	Module created.
+
+   0.2.3  Fri May 19 2017 23:58:34  tmm
+        Support eu868.
 
 */
 
@@ -54,9 +57,17 @@ public:
         Arduino_LoRaWAN_ttn_base(const lmic_pinmap & pinmap) : Super(pinmap) {};
 
 protected:
+        // the NetBegin() function does specific work when starting
+        // up; this does the common work for all TTN lorawan
+        // variants
+        virtual bool NetBegin();
+
 	// the netjoin function does any post-join work -- at present
 	// this can be shared by all networks.
 	virtual void NetJoin();
+
+        // every derivative must have a NetBeginInit.
+        virtual void NetBeginRegionInit() = 0;
 
 private:
 	};
@@ -68,8 +79,16 @@ public:
 	Arduino_LoRaWAN_ttn_eu868() {};
         Arduino_LoRaWAN_ttn_eu868(const lmic_pinmap & pinmap) : Super(pinmap) {};
 
+protected:
+        // the NetBeginInit() function does specific work for the common code
+        // when starting up.
+        virtual void NetBeginRegionInit();
+
+        // Implement the NetJoin() operations for eu868
+        virtual void NetJoin();
+
 private:
-	};
+        };
 
 class Arduino_LoRaWAN_ttn_us915 : public Arduino_LoRaWAN_ttn_base
 	{
@@ -79,10 +98,10 @@ public:
         Arduino_LoRaWAN_ttn_us915(const lmic_pinmap & pinmap) : Super(pinmap) {};
 
 protected:
-	// the NetBegin() function does specific work when starting
-	// up. For ttn we need to turn off the link check mode, and
+	// the NetBeginInit() function does specific work when starting
+	// up. For us915, we need to turn off the link check mode, and
 	// select the subband.
-	bool NetBegin();
+        virtual void NetBeginRegionInit();
 
 	// Implement the NetJoin() operations for US915
 	virtual void NetJoin();
@@ -96,6 +115,15 @@ public:
         using Super = Arduino_LoRaWAN_ttn_base;
         Arduino_LoRaWAN_ttn_as923() {};
         Arduino_LoRaWAN_ttn_as923(const lmic_pinmap & pinmap) : Super(pinmap) {};
+
+protected:
+	// the NetBeginInit() function does specific work when starting
+	// up. For us915, we need to turn off the link check mode, and
+	// select the subband.
+        virtual void NetBeginRegionInit();
+
+	// Implement the NetJoin() operations for as923
+	virtual void NetJoin();
 
 private:
 	};

--- a/src/lib/ttn_base_netbegin.cpp
+++ b/src/lib/ttn_base_netbegin.cpp
@@ -1,0 +1,98 @@
+/* ttn_base_netbegin.cpp	Fri May 19 2017 23:58:34 tmm */
+
+/*
+
+Module:  ttn_base_netbegin.cpp
+
+Function:
+	Arduino_LoRaWAN_ttn_base::NetBegin()
+
+Version:
+	V0.2.3	Fri May 19 2017 23:58:34 tmm	Edit level 1
+
+Copyright notice:
+	This file copyright (C) 2017 by
+
+		MCCI Corporation
+		3520 Krums Corners Road
+		Ithaca, NY  14850
+
+	An unpublished work.  All rights reserved.
+
+	This file is proprietary information, and may not be disclosed or
+	copied without the prior permission of MCCI Corporation.
+
+Author:
+	Terry Moore, MCCI Corporation	May 2017
+
+Revision history:
+   0.2.3  Fri May 19 2017 23:58:34  tmm
+	Module created.
+
+*/
+
+#include <Arduino_LoRaWAN_ttn.h>
+#include <Arduino_LoRaWAN_lmic.h>
+
+/****************************************************************************\
+|
+|		Manifest constants & typedefs.
+|
+\****************************************************************************/
+
+
+
+/****************************************************************************\
+|
+|	Read-only data.
+|
+\****************************************************************************/
+
+
+
+/****************************************************************************\
+|
+|	VARIABLES:
+|
+\****************************************************************************/
+
+bool Arduino_LoRaWAN_ttn_base::NetBegin()
+    {
+    //
+    // If no provisining info, return false.
+    //
+    if (this->GetProvisioningStyle() == ProvisioningStyle::kNone)
+	return false;
+
+    // Set data rate and transmit power, based on regional considerations.
+    this->NetBeginRegionInit();
+
+    //
+    // this will succeed either if provisioned for Abp, or if Otaa and we
+    // have successfully joined.  Note that ABP is just exactly the same
+    // as what happends after a join, so we use this for fetching all the
+    // required information.
+    //
+    AbpProvisioningInfo abpInfo;
+
+    if (this->GetAbpProvisioningInfo(&abpInfo))
+        {
+        LMIC_setSession(/* port */ 1,
+                abpInfo.DevAddr,
+                abpInfo.NwkSKey,
+                abpInfo.AppSKey
+                );
+
+	// set the seqnoUp and seqnoDown
+	// presumably if non-zero, somebody is stashing these
+	// in NVR
+	LMIC.seqnoUp = abpInfo.FCntUp;
+	LMIC.seqnoDn = abpInfo.FCntDown;
+
+        // because it's ABP, we need to set up the parameters we'd set
+        // after an OTAA join.
+	this->NetJoin();
+        }
+
+    return true;
+    }

--- a/src/lib/ttn_eu868_netbegin.cpp
+++ b/src/lib/ttn_eu868_netbegin.cpp
@@ -1,14 +1,14 @@
-/* ttn_us915_netbegin.cpp	Fri May 19 2017 23:58:34 tmm */
+/* ttn_eu868_netbegin.cpp	Sun Mar 12 2017 16:21:31 tmm */
 
 /*
 
-Module:  ttn_us915_netbegin.cpp
+Module:  ttn_eu868_netbegin.cpp
 
 Function:
-	Arduino_LoRaWAN_ttn_us915::NetBegin()
+	Arduino_LoRaWAN_ttn_eu868::NetBegin()
 
 Version:
-	V0.2.3	Fri May 19 2017 23:58:34 tmm	Edit level 3
+	V0.2.2	Sun Mar 12 2017 16:21:31 tmm	Edit level 2
 
 Copyright notice:
 	This file copyright (C) 2016-2017 by
@@ -18,10 +18,10 @@ Copyright notice:
 		Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-
+	
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
-
+ 
 Author:
 	Terry Moore, MCCI Corporation	November 2016
 
@@ -31,9 +31,6 @@ Revision history:
 
    0.2.2  Sun Mar 12 2017 16:21:31  tmm
 	Clarify documentation.
-
-   0.2.3  Fri May 19 2017 23:58:34  tmm
-        Refactor for eu868 support as well as us915.
 
 */
 
@@ -63,23 +60,9 @@ Revision history:
 \****************************************************************************/
 
 // protected virtual
-void Arduino_LoRaWAN_ttn_us915::NetBeginRegionInit()
+void Arduino_LoRaWAN_ttn_eu868::NetBeginRegionInit()
     {
-    // Set data rate and transmit power
-    // DR_SF7 is US DR3; 14 means 14 dBm
-
-    // XXX (tmm@mcci.com) although LMIC.adrTxpow is set to 14, it's
-    // never used inside the LMIC library. This is because LMIC's radio.c uses
-    // LMIC.txpow, and in US915, lmic.c::updatetx() sets LMIC.txpow to 30
-    // for 125kHz channels, and  26 for 500kHz channels, ignoring
-    // LMIC.adrTxpow.  Then radio.c limits to the value for 10 dBm, and
-    // apparendly doesn't even turn on the +20 dBm option if over 10 dBm.
-
-    LMIC_setDrTxpow(DR_SF7, 14);
-
-    // Select SubBand prejoin -- saves power for joining
-    // This is specific to the US915 bandplan.
-    cLMIC::SelectSubBand(
-        cLMIC::SubBand::SubBand_2 // must align with subband on gateway.
-        );
+    //
+    // for eu868, we don't need to do any special setup. 
+    //
     }

--- a/src/lib/ttn_eu868_netjoin.cpp
+++ b/src/lib/ttn_eu868_netjoin.cpp
@@ -1,0 +1,77 @@
+/* ttn_eu868_netjoin.cpp	Fri May 19 2017 23:58:34 tmm */
+
+/*
+
+Module:  ttn_eu868_netjoin.cpp
+
+Function:
+	Arduino_LoRaWAN_ttn_eu868::NetJoin()
+
+Version:
+	V0.2.3	Fri May 19 2017 23:58:34 tmm	Edit level 1
+
+Copyright notice:
+	This file copyright (C) 2017 by
+
+		MCCI Corporation
+		3520 Krums Corners Road
+		Ithaca, NY  14850
+
+	An unpublished work.  All rights reserved.
+
+	This file is proprietary information, and may not be disclosed or
+	copied without the prior permission of MCCI Corporation.
+
+Author:
+	Terry Moore, MCCI Corporation	May 2017
+
+Revision history:
+   0.2.3  Fri May 19 2017 23:58:34  tmm
+	Module created.
+
+*/
+
+#include <Arduino_LoRaWAN_ttn.h>
+#include <Arduino_LoRaWAN_lmic.h>
+
+/****************************************************************************\
+|
+|		Manifest constants & typedefs.
+|
+|	This is strictly for private types and constants which will not
+|	be exported.
+|
+\****************************************************************************/
+
+
+
+/****************************************************************************\
+|
+|	Read-only data.
+|
+|	If program is to be ROM-able, these must all be tagged read-only
+|	using the ROM storage class; they may be global.
+|
+\****************************************************************************/
+
+
+
+/****************************************************************************\
+|
+|	VARIABLES:
+|
+|	If program is to be ROM-able, these must be initialized
+|	using the BSS keyword.  (This allows for compilers that require
+|	every variable to have an initializer.)  Note that only those
+|	variables owned by this module should be declared here, using the BSS
+|	keyword; this allows for linkers that dislike multiple declarations
+|	of objects.
+|
+\****************************************************************************/
+
+
+void Arduino_LoRaWAN_ttn_eu868::NetJoin()
+	{
+	// do the common work.
+	this->Super::NetJoin();
+	}


### PR DESCRIPTION
We have use for EU868 now, and for other bandplans in the near future. When we turned on eu868 support (going from one bandplan supported to two) we noticed a number of mistakes; this patch set fixes them.

BTW: we still disable ADR in US915 because we have not had time to test that. 