### PR TITLE
Add rxtx_rx_active and spi_freq in the lmic_pinmap structure.

### DIFF
--- a/src/Arduino_LoRaWAN.h
+++ b/src/Arduino_LoRaWAN.h
@@ -81,8 +81,8 @@ public:
                 uint8_t rxtx;
                 uint8_t rst;
                 uint8_t dio[NUM_DIO];
-		uint8_t rxtx_rx_active;
-		uint32_t spi_freq;
+                uint8_t rxtx_rx_active;
+                uint32_t spi_freq;
                 };
 
 

--- a/src/Arduino_LoRaWAN.h
+++ b/src/Arduino_LoRaWAN.h
@@ -77,6 +77,8 @@ public:
                 uint8_t rxtx;
                 uint8_t rst;
                 uint8_t dio[NUM_DIO];
+		uint8_t rxtx_rx_active;
+		uint32_t spi_freq;
                 };
 
 

--- a/src/Arduino_LoRaWAN.h
+++ b/src/Arduino_LoRaWAN.h
@@ -68,6 +68,10 @@ public:
 	     LOG_VERBOSE = 1 << 2,
 	     };
 
+	// We must replicate the C structure from
+	// "lmic.h" inside the class. Otherwise we'd
+	// need to have all of lmic.h in scope everywhere,
+	// which could cause naming clashes.
         struct lmic_pinmap {
                 // Use this for any unused pins.
                 static constexpr uint8_t LMIC_UNUSED_PIN = 0xff;

--- a/src/lib/arduino_lorawan.cpp
+++ b/src/lib/arduino_lorawan.cpp
@@ -70,7 +70,15 @@ Revision history:
 
 Arduino_LoRaWAN::Arduino_LoRaWAN()
         {
+	// initialize the pin structure, which mostly needs to be 
+	// lmic_pinmap::LMIC_UNUSED_PIN
         memset(&this->m_lmic_pins, lmic_pinmap::LMIC_UNUSED_PIN, sizeof(this->m_lmic_pins));
+	
+	// However, a few fields need to be different.
+	// By default, we want the RX/TX pin to be high for TX.
         this->m_lmic_pins.rxtx_rx_active = 0;
+	
+	// By default, use the SPI frequency that comes from the LMIC
+	// configuration file.
         this->m_lmic_pins.spi_freq = 0;	/* use default */
         }

--- a/src/lib/arduino_lorawan.cpp
+++ b/src/lib/arduino_lorawan.cpp
@@ -71,4 +71,6 @@ Revision history:
 Arduino_LoRaWAN::Arduino_LoRaWAN()
         {
         memset(&this->m_lmic_pins, lmic_pinmap::LMIC_UNUSED_PIN, sizeof(this->m_lmic_pins));
+        this->m_lmic_pins.rxtx_rx_active = 0;
+        this->m_lmic_pins.spi_freq = 0;	/* use default */
         }

--- a/src/lib/arduino_lorawan_begin.cpp
+++ b/src/lib/arduino_lorawan_begin.cpp
@@ -61,6 +61,8 @@ bool Arduino_LoRaWAN::begin()
     s_lmic_pins.rxtx = this->m_lmic_pins.rxtx;
     s_lmic_pins.rst = this->m_lmic_pins.rst;
     memcpy(s_lmic_pins.dio, this->m_lmic_pins.dio, sizeof(s_lmic_pins.dio));
+    s_lmic_pins.rxtx_rx_active = this->m_lmic_pins.rxtx_rx_active;
+    s_lmic_pins.spi_freq = this->m_lmic_pins.spi_freq;
 
     // LMIC init
     if (! os_init_ex(&s_lmic_pins))

--- a/src/lib/arduino_lorawan_begin.cpp
+++ b/src/lib/arduino_lorawan_begin.cpp
@@ -57,6 +57,10 @@ bool Arduino_LoRaWAN::begin()
     Arduino_LoRaWAN::pLoRaWAN = this;
 
     // set up the LMIC pinmap.
+    // this is a little awkward because we don't want the LMIC
+    // header in scope everywhere, so we have a duplicate C++
+    // structure that's part of the class. Therefore we have to
+    // copy element by element.
     s_lmic_pins.nss = this->m_lmic_pins.nss;
     s_lmic_pins.rxtx = this->m_lmic_pins.rxtx;
     s_lmic_pins.rst = this->m_lmic_pins.rst;


### PR DESCRIPTION
Add rxtx_rx_active and spi_freq in the lmic_pinmap structure for Murata based Catena 4551.