### PR TITLE
Fix #88: use new LMIC APIs for SendBuffer

### DIFF
--- a/src/lib/GetTxReady.cpp
+++ b/src/lib/GetTxReady.cpp
@@ -70,10 +70,30 @@ Revision history:
 |
 \****************************************************************************/
 
-bool Arduino_LoRaWAN::GetTxReady()
+/*
+
+Name:   Arduino_LoRaWAN::GetTxReady()
+
+Function:
+        Return TRUE if the LMIC can accept a transmit operation.
+
+Definition:
+        public bool Arduino_LoRaWAN::GetTxReady() const;
+
+Description:
+        If the LMIC is already processing a message, or if there's
+        a message in the Arduino_LoRaWAN queue being processed,
+        then transmit is not ready. Otherwise, transmit is ready.
+
+Returns:
+        true if ready for a message, false otherwise.
+
+*/
+
+bool Arduino_LoRaWAN::GetTxReady() const
         {
         if (LMIC.opmode & OP_TXRXPEND)
                 return false;
         else
-                return ! this->m_fTxPending;
+                return ! this->m_SendBufferData.fTxPending;
         }

--- a/src/lib/arduino_lorawan_begin.cpp
+++ b/src/lib/arduino_lorawan_begin.cpp
@@ -169,12 +169,6 @@ void Arduino_LoRaWAN::StandardEventProcessor(
         case EV_BEACON_TRACKED:
             break;
         case EV_JOINING:
-            // if we're joining, try to see if we have OTAA info. If not
-            // we need to just reset.
-            if (! this->GetOtaaProvisioningInfo(nullptr))
-                {
-                this->completeTx(false);
-                }
             break;
 
         case EV_JOINED:
@@ -220,10 +214,6 @@ void Arduino_LoRaWAN::StandardEventProcessor(
 
             // notify framework that tx is complete
             this->NetTxComplete();
-
-            // notify client that TX is complete; claim success unless
-            // it's confirmed and we didn't get an ACK.
-            this->completeTx(! LMIC.pendTxConf || (LMIC.txrxFlags & TXRX_ACK) != 0);
             break;
 
         case EV_LOST_TSYNC:
@@ -257,7 +247,9 @@ void Arduino_LoRaWAN::StandardEventProcessor(
             break;
 
         case EV_TXCANCELED:
-            this->completeTx(false);
+            break;
+
+        case EV_JOIN_TXCOMPLETE:
             break;
 
         default:


### PR DESCRIPTION
This turned out to be a source of confusion and instability (as well as duplicating code in two layers).

Also in this change, I added some comments; changed the layout of the (incomplete) SessionInfoV2 structure to match SessionInfoV1, changed API `GetTxReady()` to be `const` in its reference to `this`, and made some other cosmetic changes. (I would break up the commits, but time presses.)