### PR TITLE
Add MCCI LoRaWAN LMIC library to depends field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -9,4 +9,4 @@ url=https://github.com/mcci-catena/arduino-lorawan/
 architectures=*
 dot_a_linkage=true
 includes=Arduino_LoRaWAN.h
-depends=MCCI Arduino Development Kit ADK
+depends=MCCI Arduino Development Kit ADK, MCCI LoRaWAN LMIC library


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format