### PR TITLE
TTN V3 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The classes in this library are normally intended to be used inside a class that
 
 ### Using the LMIC's pre-configured pin-maps
 
-The stand-alone use pattern is as follows, targeting The Things Network V2.  This code can be found in the `example/simple_feather/simple.ino` sketch.  Note that this isn't complete, as you have to add code in the indicated places.
+The stand-alone use pattern is as follows, targeting The Things Network V3 (also works with V2).  This code can be found in the `example/simple_feather/simple.ino` sketch.  Note that this isn't complete, as you have to add code in the indicated places.
 
 ```c++
 #include <Arduino_LoRaWAN_ttn.h>
@@ -138,11 +138,12 @@ public:
     cMyLoRaWAN() {};
 
 protected:
-    // you'll need to provide implementations for each of the following.
+    // you'll need to provide implementations for this.
     virtual bool GetOtaaProvisioningInfo(Arduino_LoRaWAN::OtaaProvisioningInfo*) override;
-    virtual void NetSaveFCntUp(uint32_t uFCntUp) override;
-    virtual void NetSaveFCntDown(uint32_t uFCntDown) override;
+    // if you have persistent storage, you can provide implementations for these:
     virtual void NetSaveSessionInfo(const SessionInfo &Info, const uint8_t *pExtraInfo, size_t nExtraInfo) override;
+    virtual void NetSaveSessionState(const SessionState &State) override;
+    virtual bool NetGetSessionState(SessionState &State) override;
 };
 
 // set up the data structures.
@@ -167,16 +168,6 @@ cMyLoRaWAN::GetOtaaProvisioningInfo(
 }
 
 void
-cMyLoRaWAN::NetSaveFCntDown(uint32_t uFCntDown) {
-    // save uFcntDown somwwhere
-}
-
-void
-cMyLoRaWAN::NetSaveFCntUp(uint32_t uFCntUp) {
-    // save uFCntUp somewhere
-}
-
-void
 cMyLoRaWAN::NetSaveSessionInfo(
     const SessionInfo &Info,
     const uint8_t *pExtraInfo,
@@ -184,6 +175,19 @@ cMyLoRaWAN::NetSaveSessionInfo(
     ) {
     // save Info somewhere.
 }
+
+void
+cMyLoRaWAN::NetSaveSessionState(const SessionState &State) {
+    // save State somwwhere. Note that it's often the same;
+    // often only the frame counters change.
+}
+
+bool
+cMyLoRaWAN::NetGetSessionState(SessionState &State) {
+    // either fetch SessionState from somewhere and return true or...
+    return false;
+}
+
 ```
 
 ### Supplying a pin-map

--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -26,12 +26,12 @@ public:
     cMyLoRaWAN() {};
 
 protected:
-    // you'll need to provide implementations for each of the following.
+    // you'll need to provide implementation for this.
     virtual bool GetOtaaProvisioningInfo(Arduino_LoRaWAN::OtaaProvisioningInfo*) override;
-    virtual void NetSaveFCntUp(uint32_t uFCntUp) override;
-    virtual void NetSaveFCntDown(uint32_t uFCntDown) override;
+    // if you have persistent storage, you can provide implementations for these:
     virtual void NetSaveSessionInfo(const SessionInfo &Info, const uint8_t *pExtraInfo, size_t nExtraInfo) override;
-
+    virtual void NetSaveSessionState(const SessionState &State) override;
+    virtual bool NetGetSessionState(SessionState &State) override;
 };
 
 // set up the data structures.
@@ -58,20 +58,23 @@ cMyLoRaWAN::GetOtaaProvisioningInfo(
 }
 
 void
-cMyLoRaWAN::NetSaveFCntDown(uint32_t uFCntDown) {
-    // save uFcntDown somwwhere
-}
-
-void
-cMyLoRaWAN::NetSaveFCntUp(uint32_t uFCntUp) {
-    // save uFCntUp somewhere
-}
-
-void
 cMyLoRaWAN::NetSaveSessionInfo(
     const SessionInfo &Info,
     const uint8_t *pExtraInfo,
     size_t nExtraInfo
     ) {
     // save Info somewhere.
+}
+
+
+void
+cMyLoRaWAN::NetSaveSessionState(const SessionState &State) {
+    // save State somwwhere. Note that it's often the same;
+    // often only the frame counters change.
+}
+
+bool
+cMyLoRaWAN::NetGetSessionState(SessionState &State) {
+    // either fetch SessionState from somewhere and return true or...
+    return false;
 }

--- a/examples/simple_feather/simple_feather.ino
+++ b/examples/simple_feather/simple_feather.ino
@@ -26,12 +26,12 @@ public:
     cMyLoRaWAN() {};
 
 protected:
-    // you'll need to provide implementations for each of the following.
+    // you'll need to provide implementation for this.
     virtual bool GetOtaaProvisioningInfo(Arduino_LoRaWAN::OtaaProvisioningInfo*) override;
-    virtual void NetSaveFCntUp(uint32_t uFCntUp) override;
-    virtual void NetSaveFCntDown(uint32_t uFCntDown) override;
+    // if you have persistent storage, you can provide implementations for these:
     virtual void NetSaveSessionInfo(const SessionInfo &Info, const uint8_t *pExtraInfo, size_t nExtraInfo) override;
-
+    virtual void NetSaveSessionState(const SessionState &State) override;
+    virtual bool NetGetSessionState(SessionState &State) override;
 };
 
 // set up the data structures.
@@ -72,20 +72,22 @@ cMyLoRaWAN::GetOtaaProvisioningInfo(
 }
 
 void
-cMyLoRaWAN::NetSaveFCntDown(uint32_t uFCntDown) {
-    // save uFcntDown somwwhere
-}
-
-void
-cMyLoRaWAN::NetSaveFCntUp(uint32_t uFCntUp) {
-    // save uFCntUp somewhere
-}
-
-void
 cMyLoRaWAN::NetSaveSessionInfo(
     const SessionInfo &Info,
     const uint8_t *pExtraInfo,
     size_t nExtraInfo
     ) {
     // save Info somewhere.
+}
+
+void
+cMyLoRaWAN::NetSaveSessionState(const SessionState &State) {
+    // save State somwwhere. Note that it's often the same;
+    // often only the frame counters change.
+}
+
+bool
+cMyLoRaWAN::NetGetSessionState(SessionState &State) {
+    // either fetch SessionState from somewhere and return true or...
+    return false;
 }

--- a/src/Arduino_LoRaWAN.h
+++ b/src/Arduino_LoRaWAN.h
@@ -34,7 +34,7 @@ Author:
 ///     \ref ARDUINO_LORAWAN_VERSION_COMPARE_LT() to compare relative versions.
 ///
 #define ARDUINO_LORAWAN_VERSION \
-        ARDUINO_LORAWAN_VERSION_CALC(0, 9, 0, 10) /* v0.9.0-10 */
+        ARDUINO_LORAWAN_VERSION_CALC(0, 9, 0, 11) /* v0.9.0-11 */
 
 #define ARDUINO_LORAWAN_VERSION_GET_MAJOR(v)    \
         (((v) >> 24u) & 0xFFu)

--- a/src/Arduino_LoRaWAN.h
+++ b/src/Arduino_LoRaWAN.h
@@ -34,7 +34,7 @@ Author:
 ///     \ref ARDUINO_LORAWAN_VERSION_COMPARE_LT() to compare relative versions.
 ///
 #define ARDUINO_LORAWAN_VERSION \
-        ARDUINO_LORAWAN_VERSION_CALC(0, 9, 0, 11) /* v0.9.0-11 */
+        ARDUINO_LORAWAN_VERSION_CALC(0, 9, 0, 12) /* v0.9.0-12 */
 
 #define ARDUINO_LORAWAN_VERSION_GET_MAJOR(v)    \
         (((v) >> 24u) & 0xFFu)

--- a/src/Arduino_LoRaWAN.h
+++ b/src/Arduino_LoRaWAN.h
@@ -25,11 +25,16 @@ Author:
 #include <cstring>
 #include <arduino_lmic_hal_configuration.h>
 
-// Arduino LoRaWAN version
+/// \brief construct Arduino LoRaWAN semantic version
 #define ARDUINO_LORAWAN_VERSION_CALC(major, minor, patch, local)        \
         (((major) << 24u) | ((minor) << 16u) | ((patch) << 8u) | (local))
 
-#define ARDUINO_LORAWAN_VERSION ARDUINO_LORAWAN_VERSION_CALC(0, 8, 0, 0)        /* v0.8.0.0 */
+/// \brief library semantic version
+/// \note local "0" is *greater than* any local non-zero; use
+///     \ref ARDUINO_LORAWAN_VERSION_COMPARE_LT() to compare relative versions.
+///
+#define ARDUINO_LORAWAN_VERSION \
+        ARDUINO_LORAWAN_VERSION_CALC(0, 9, 0, 10) /* v0.9.0-10 */
 
 #define ARDUINO_LORAWAN_VERSION_GET_MAJOR(v)    \
         (((v) >> 24u) & 0xFFu)
@@ -43,7 +48,19 @@ Author:
 #define ARDUINO_LORAWAN_VERSION_GET_LOCAL(v)    \
         ((v) & 0xFFu)
 
+/// \brief convert a semantic version to an integer.
+#define ARDUINO_LORAWAN_VERSION_TO_INT(v)       \
+        (((v) & 0xFFFFFF00u) | (((v) - 1) & 0xFFu))
 
+/// \brief compare two semantic versions
+/// \return \c true if \b a is less than \b b (as a semantic version).
+#define ARDUINO_LORAWAN_VERSION_COMPARE_LT(a, b)   \
+        (ARDUINO_LORAWAN_VERSION_TO_INT(a) < ARDUINO_LORAWAN_VERSION_TO_INT(b))
+
+/// \brief compare two semantic versions
+/// \return \c true if \b a is greater than \b b (as a semantic version).
+#define ARDUINO_LORAWAN_VERSION_COMPARE_GT(a, b)   \
+        (ARDUINO_LORAWAN_VERSION_TO_INT(a) > ARDUINO_LORAWAN_VERSION_TO_INT(b))
 
 class Arduino_LoRaWAN;
 

--- a/src/Arduino_LoRaWAN.h
+++ b/src/Arduino_LoRaWAN.h
@@ -198,7 +198,7 @@ public:
         template <uint32_t a_nCh>
         struct SessionChannelMask_US_like
                 {
-                static constexpr uint32_t nCh = a_nCh; 
+                static constexpr uint32_t nCh = a_nCh;
                 static_assert(
                         1 <= a_nCh && a_nCh <= 96,
                         "number of channels must be in [1..96]"
@@ -293,7 +293,7 @@ public:
                 uint8_t                         UplinkFreq[nCh * 3];            ///< packed downlink frequencies for each channel (100 Hz units)
                 uint8_t                         DownlinkFreq[nCh * 3];          ///< packed uplink frequencies for each channel.
                 SessionChannelBand              Bands[nBands];                  ///< band limiting info
-        
+
                 // useful methods
                 ///
                 /// \brief set the band number for a given channel
@@ -308,7 +308,7 @@ public:
 
                         this->ChannelBands ^= (this->ChannelBands ^ v) & mask;
                         }
-                
+
                 ///
                 /// \brief get the band for a given channel
                 ///
@@ -427,7 +427,7 @@ public:
         ///
         /// \details
         /// This structure is stored persistenly if
-        /// possible, and represents the result of a join. We allow for 
+        /// possible, and represents the result of a join. We allow for
         /// versioning, primarily so that (if we
         /// choose) we can accommodate older versions and very simple
         /// storage schemes.
@@ -893,7 +893,7 @@ private:
                 if (this->m_savedSessionState.Header.Tag == kSessionStateTag_V1 &&
                     this->m_savedSessionState.V1.FCntDown == newFCntDown)
                         return;
-                
+
                 this->SaveSessionState();
                 }
 
@@ -913,7 +913,7 @@ private:
         ///
         /// \brief apply session state data to current LMIC session
         ///
-        /// \param [in] State 
+        /// \param [in] State
         bool ApplySessionState(const SessionState &State);
 
         ///

--- a/src/Arduino_LoRaWAN_Helium.h
+++ b/src/Arduino_LoRaWAN_Helium.h
@@ -82,8 +82,6 @@ private:
 #   error "Helium network in US915 region is fixed at subband channels 8~15/65"
 # endif
 # define Arduino_LoRaWAN_REGION_TAG us915
-#elif ARDUINO_LMIC_CFG_NETWORK_HELIUM
-# error "Configured region not supported for Helium: can't define Arduino_LoRaWAN_REGION_TAG"
 #else
 // just be silent if we don't think we're targeting Helium
 #endif

--- a/src/Arduino_LoRaWAN_Helium.h
+++ b/src/Arduino_LoRaWAN_Helium.h
@@ -78,8 +78,8 @@ private:
 
 
 #if ARDUINO_LMIC_CFG_NETWORK_HELIUM && defined(CFG_us915)
-# if defined(ARDUINO_LMIC_CFG_SUBBAND) && ! (ARDUINO_LMIC_CFG_SUBBAND == -1 || ARRDUINO_LMIC_CFG_SUBBAND == 6)
-#   error "Helium network in US915 region is fixed at subband channels 48~55/70"
+# if defined(ARDUINO_LMIC_CFG_SUBBAND) && ! (ARDUINO_LMIC_CFG_SUBBAND == -1 || ARDUINO_LMIC_CFG_SUBBAND == 1)
+#   error "Helium network in US915 region is fixed at subband channels 8~15/65"
 # endif
 # define Arduino_LoRaWAN_REGION_TAG us915
 #elif ARDUINO_LMIC_CFG_NETWORK_HELIUM

--- a/src/Arduino_LoRaWAN_Senet.h
+++ b/src/Arduino_LoRaWAN_Senet.h
@@ -78,7 +78,7 @@ private:
 
 
 #if ARDUINO_LMIC_CFG_NETWORK_SENET && defined(CFG_us915)
-# if defined(ARDUINO_LMIC_CFG_SUBBAND) && ! (ARDUINO_LMIC_CFG_SUBBAND == -1 || ARRDUINO_LMIC_CFG_SUBBAND == 0)
+# if defined(ARDUINO_LMIC_CFG_SUBBAND) && ! (ARDUINO_LMIC_CFG_SUBBAND == -1 || ARDUINO_LMIC_CFG_SUBBAND == 0)
 #   warning "Senet network in US915 region should use generic subband or subband zero (channels 0~7/64)"
 # endif
 # define Arduino_LoRaWAN_REGION_TAG us915

--- a/src/Arduino_LoRaWAN_network.h
+++ b/src/Arduino_LoRaWAN_network.h
@@ -18,34 +18,6 @@ Author:
 
 #include "Arduino_LoRaWAN.h"
 
-// count number of defined networks
-#define ARDUINO_LORAWAN_NETWORK_COUNT   \
-        defined(ARDUINO_LMIC_CFG_NETWORK_TTN) + \
-        defined(ARDUINO_LMIC_CFG_NETWORK_ACTILITY) + \
-        defined(ARDUINO_LMIC_CFG_NETWORK_HELIUM) + \
-        defined(ARDUINO_LMIC_CFG_NETWORK_MACHINEQ) + \
-        defined(ARDUINO_LMIC_CFG_NETWORK_SENET) + \
-        defined(ARDUINO_LMIC_CFG_NETWORK_SENRA) + \
-        defined(ARDUINO_LMIC_CFG_NETWORK_SWISSCOM) + \
-        defined(ARDUINO_LMIC_CFG_NETWORK_CHIRPSTACK) + \
-        defined(ARDUINO_LMIC_CFG_NETWORK_GENERIC)
-
-#if ARDUINO_LORAWAN_NETWORK_COUNT == 0
-// none defined, query legacy symbols
-# ifdef ARDUINO_LORAWAN_NETWORK_TTN
-#  define ARDUINO_LMIC_CFG_NETWORK_TTN 1
-# elif defined(ARDUINO_LORAWAN_NETWORK_MACHINEQ)
-#  define ARDUINO_LMIC_CFG_NETWORK_MACHINEQ 1
-# else
-   // no legacy and no BSP: use TTN.
-#  define ARDUINO_LMIC_CFG_NETWORK_TTN 1
-# endif
-#endif
-
-#if ARDUINO_LORAWAN_NETWORK_COUNT > 1
-# error "Multiple ARDUINO_LMIC_CFG_NETWORK_* values defined"
-#endif
-
 // so we don't need to #ifdef, give all the ARDUINO_LMIC_CFG_ variables a value.
 #if !defined(ARDUINO_LMIC_CFG_NETWORK_TTN)
 # define ARDUINO_LMIC_CFG_NETWORK_TTN 0
@@ -73,6 +45,41 @@ Author:
 #endif
 #if !defined(ARDUINO_LMIC_CFG_NETWORK_GENERIC)
 # define ARDUINO_LMIC_CFG_NETWORK_GENERIC 0
+#endif
+
+// count number of defined networks
+#define ARDUINO_LORAWAN_NETWORK_COUNT   \
+        (ARDUINO_LMIC_CFG_NETWORK_TTN + \
+         ARDUINO_LMIC_CFG_NETWORK_ACTILITY + \
+         ARDUINO_LMIC_CFG_NETWORK_HELIUM + \
+         ARDUINO_LMIC_CFG_NETWORK_MACHINEQ + \
+         ARDUINO_LMIC_CFG_NETWORK_SENET + \
+         ARDUINO_LMIC_CFG_NETWORK_SENRA + \
+         ARDUINO_LMIC_CFG_NETWORK_SWISSCOM + \
+         ARDUINO_LMIC_CFG_NETWORK_CHIRPSTACK + \
+         ARDUINO_LMIC_CFG_NETWORK_GENERIC)
+
+#if ARDUINO_LORAWAN_NETWORK_COUNT == 0
+// none defined, query legacy symbols
+# ifdef ARDUINO_LORAWAN_NETWORK_TTN
+#  undef ARDUINO_LMIC_CFG_NETWORK_TTN
+#  define ARDUINO_LMIC_CFG_NETWORK_TTN 1
+# elif defined(ARDUINO_LORAWAN_NETWORK_MACHINEQ)
+#  undef ARDUINO_LMIC_CFG_NETWORK_MACHINEQ
+#  define ARDUINO_LMIC_CFG_NETWORK_MACHINEQ 1
+# else
+   // no legacy and no BSP: use TTN.
+#  undef ARDUINO_LMIC_CFG_NETWORK_TTN
+#  define ARDUINO_LMIC_CFG_NETWORK_TTN 1
+# endif
+#endif
+
+#if ARDUINO_LORAWAN_NETWORK_COUNT > 1
+# error "Multiple ARDUINO_LMIC_CFG_NETWORK_* values defined"
+#endif
+
+#ifndef ARDUINO_LMIC_CFG_SUBBAND
+# define ARDUINO_LMIC_CFG_SUBBAND -1
 #endif
 
 #if ARDUINO_LMIC_CFG_NETWORK_TTN

--- a/src/Arduino_LoRaWAN_ttn.h
+++ b/src/Arduino_LoRaWAN_ttn.h
@@ -185,12 +185,12 @@ private:
 #if defined(CFG_eu868)
 # define Arduino_LoRaWAN_REGION_TAG eu868
 #elif defined(CFG_us915)
-# if ARDUINO_LMIC_CFG_NETWORK_TTN && defined(ARDUINO_LMIC_CFG_SUBBAND) && ! (ARDUINO_LMIC_CFG_SUBBAND == -1 || ARRDUINO_LMIC_CFG_SUBBAND == 1)
+# if ARDUINO_LMIC_CFG_NETWORK_TTN && defined(ARDUINO_LMIC_CFG_SUBBAND) && ! (ARDUINO_LMIC_CFG_SUBBAND == -1 || ARDUINO_LMIC_CFG_SUBBAND == 1)
 #  error "The Things Network network in US915 region is fixed at subband channels 8~15/65"
 # endif
 # define Arduino_LoRaWAN_REGION_TAG us915
 #elif defined(CFG_au915)
-# if ARDUINO_LMIC_CFG_NETWORK_TTN && defined(ARDUINO_LMIC_CFG_SUBBAND) && ! (ARDUINO_LMIC_CFG_SUBBAND == -1 || ARRDUINO_LMIC_CFG_SUBBAND == 1)
+# if ARDUINO_LMIC_CFG_NETWORK_TTN && defined(ARDUINO_LMIC_CFG_SUBBAND) && ! (ARDUINO_LMIC_CFG_SUBBAND == -1 || ARDUINO_LMIC_CFG_SUBBAND == 1)
 #  error "The Things Network network in AU915 region is fixed at subband channels 8~15/65"
 # endif
 # define Arduino_LoRaWAN_REGION_TAG au915

--- a/src/lib/GetCountryCode.cpp
+++ b/src/lib/GetCountryCode.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
 	See accompanying LICENSE file.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	June 2018
 

--- a/src/lib/GetRegion.cpp
+++ b/src/lib/GetRegion.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
 	See accompanying LICENSE file.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	June 2018
 

--- a/src/lib/GetRegionString.cpp
+++ b/src/lib/GetRegionString.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
 	See accompanying LICENSE file.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	June 2018
 

--- a/src/lib/GetTxReady.cpp
+++ b/src/lib/GetTxReady.cpp
@@ -18,10 +18,10 @@ Copyright notice:
                 Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	October 2016
 

--- a/src/lib/LogPrintf.cpp
+++ b/src/lib/LogPrintf.cpp
@@ -13,9 +13,9 @@ Copyright notice:
 		Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	See accompanying LICENSE file.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	November 2016
 
@@ -78,7 +78,7 @@ static bool CheckDtr(TMap& m)
 
 void
 Arduino_LoRaWAN::LogPrintf(
-	const char *fmt, 
+	const char *fmt,
 	...
 	)
 	{

--- a/src/lib/SendBuffer.cpp
+++ b/src/lib/SendBuffer.cpp
@@ -18,10 +18,10 @@ Copyright notice:
                 Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	October 2016
 

--- a/src/lib/SetLinkCheckMode.cpp
+++ b/src/lib/SetLinkCheckMode.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
 	See accompanying LICENSE file.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	June 2018
 

--- a/src/lib/actility_eu868_netbeginregioninit.cpp
+++ b/src/lib/actility_eu868_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
     See LICENSE file accompanying this project.
- 
+
 Author:
     Terry Moore, MCCI Corporation	February 2020
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_Actility_eu868::NetBeginRegionInit()
     {
     //
-    // for eu868, we don't need to do any special setup. 
+    // for eu868, we don't need to do any special setup.
     //
     }

--- a/src/lib/actility_in866_netbeginregioninit.cpp
+++ b/src/lib/actility_in866_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
         See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	February 2020
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_Actility_in866::NetBeginRegionInit()
     {
     //
-    // for in866, we don't need to do any special setup. 
+    // for in866, we don't need to do any special setup.
     //
     }

--- a/src/lib/actility_kr920_netbeginregioninit.cpp
+++ b/src/lib/actility_kr920_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
         See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	February 2020
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_Actility_kr920::NetBeginRegionInit()
     {
     //
-    // for kr920, we don't need to do any special setup. 
+    // for kr920, we don't need to do any special setup.
     //
     }

--- a/src/lib/actility_us915_netjoin.cpp
+++ b/src/lib/actility_us915_netjoin.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
     See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	February 2020
 

--- a/src/lib/arduino_lorawan.cpp
+++ b/src/lib/arduino_lorawan.cpp
@@ -18,10 +18,10 @@ Copyright notice:
 		Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	October 2016
 

--- a/src/lib/arduino_lorawan_begin.cpp
+++ b/src/lib/arduino_lorawan_begin.cpp
@@ -173,13 +173,11 @@ void
 Arduino_LoRaWAN::SaveSessionInfo()
     {
     SessionInfo Info;
-    Info.V1.Tag = kSessionInfoTag_V1;
+    Info.V1.Tag = kSessionInfoTag_V2;
     Info.V1.Size = sizeof(Info);
     Info.V1.Rsv2 = 0;
     Info.V1.Rsv3 = 0;
     LMIC_getSessionKeys(&Info.V1.NetID, &Info.V1.DevAddr, Info.V1.NwkSKey, Info.V1.AppSKey);
-    Info.V1.FCntUp = LMIC.seqnoUp;
-    Info.V1.FCntDown = LMIC.seqnoDn;
     this->NetSaveSessionInfo(Info, nullptr, 0);
     }
 

--- a/src/lib/arduino_lorawan_loop.cpp
+++ b/src/lib/arduino_lorawan_loop.cpp
@@ -18,10 +18,10 @@ Copyright notice:
                 Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	October 2016
 

--- a/src/lib/arduino_lorawan_sessionstate.cpp
+++ b/src/lib/arduino_lorawan_sessionstate.cpp
@@ -1,0 +1,368 @@
+/*
+
+Module:	arduino_lorawan_sessionstate.cpp
+
+Function:
+	Methods to construct and apply saved session state.
+
+Copyright and License:
+	This file copyright (C) 2021 by
+
+		MCCI Corporation
+		3520 Krums Corners Road
+		Ithaca, NY  14850
+
+	See accompanying LICENSE file for copyright and license information.
+
+Author:
+	Terry Moore, MCCI Corporation	March 2021
+
+*/
+
+#include <Arduino_LoRaWAN.h>
+
+#include <arduino_lmic_hal_boards.h>
+#include <Arduino_LoRaWAN_lmic.h>
+
+/*
+
+Name:	Arduino_LoRaWAN::BuildSessionState()
+
+Function:
+	Build a SessionState structure based on current LMIC state.
+
+Definition:
+	void Arduino_LoRaWAN::BuildSessionState(
+		Arduino_LoRaWAN::SessionState &State
+		);
+
+Description:
+	Session state is extracted from the LMIC data structure and
+	placed into `State`.
+
+Returns:
+	No explicit result.
+
+Notes:
+	
+
+*/
+
+#define FUNCTION "Arduino_LoRaWAN::BuildSessionState"
+
+void
+Arduino_LoRaWAN::BuildSessionState(
+	Arduino_LoRaWAN::SessionState &State
+	) const
+	{
+    const auto tNow = os_getTime();
+
+    memset(&State, 0, sizeof(State));
+
+    State.Header.Tag = kSessionStateTag_V1;
+    State.Header.Size = sizeof(State);
+    State.V1.Region = uint8_t(this->GetRegion());
+    State.V1.LinkDR = LMIC.datarate;
+
+    State.V1.FCntUp = LMIC.seqnoUp;
+    State.V1.FCntDown = LMIC.seqnoDn;
+    // TODO(tmm@mcci.com): set GPS time to our best idea
+    // State.V1.gpsTime = 0; -- already try via memset().
+    State.V1.globalAvail = LMIC.globalDutyAvail - tNow;
+    State.V1.Rx2Frequency = LMIC.dn2Freq;
+
+#if !defined(DISABLE_PING)
+    State.V1.PingFrequency = LMIC.ping.freq;
+#endif
+
+    State.V1.Country = uint16_t(this->GetCountryCode());
+    State.V1.LinkIntegrity = LMIC.adrAckReq;
+    State.V1.TxPower = LMIC.adrTxPow;
+    State.V1.Redundancy = LMIC.upRepeat;
+    State.V1.DutyCycle = LMIC.globalDutyRate;
+    State.V1.Rx1DRoffset = LMIC.rx1DrOffset;
+    State.V1.Rx2DataRate = LMIC.dn2Dr;
+    State.V1.RxDelay = LMIC.rxDelay;
+#if LMIC_ENABLE_TxParamSetupReq
+    State.V1.TxParam = LMIC.txParam;
+#endif
+#if !defined(DISABLE_BEACONS)
+    State.V1.BeaconChannel = LMIC.bcnChnl;
+#endif
+#if !defined(DISABLE_PING)
+    State.V1.PingDr = LMIC.ping.dr;
+#endif
+    State.V1.MacRxParamAns = LMIC.dn2Ans;
+    State.V1.MacDlChannelAns = LMIC.macDlChannelAns;
+    State.V1.MacRxTimingSetupAns = LMIC.macRxTimingSetupAns;
+
+    // handle EU like regions
+#if CFG_LMIC_EU_like
+    State.V1.Channels.Header.Tag = State.V1.Channels.Header.kEUlike;
+    State.V1.Channels.Header.Tag = sizeof(State.V1.Channels.EUlike);
+    State.V1.Channels.EUlike.clearAll();
+    constexpr unsigned maxCh = MAX_CHANNELS < State.V1.Channels.EUlike.nCh ? MAX_CHANNELS : State.V1.Channels.EUlike.nCh;
+    State.V1.Channels.EUlike.ChannelMap = LMIC.channelMap;
+    // EU: save channel settings
+    for (unsigned ch = 0; ch < maxCh; ++ch)
+        {
+        auto const freq = LMIC.channelFreq[ch];
+        State.V1.Channels.EUlike.setFrequency(State.V1.Channels.EUlike.UplinkFreq, ch, freq & ~3);
+        State.V1.Channels.EUlike.setBand(ch, freq & 3);
+        State.V1.Channels.EUlike.ChannelDrMap[ch] = LMIC.channelDrMap[ch];
+
+#if !defined(DISABLE_MCMD_DlChannelReq)
+        State.V1.Channels.EUlike.setFrequency(State.V1.Channels.EUlike.DownlinkFreq, ch, LMIC.channelDlFreq[ch]);
+#endif
+        }
+
+    // EU: save band state
+    for (unsigned iBand = 0; iBand < State.V1.Channels.EUlike.nBands; ++iBand)
+        {
+        auto & band = State.V1.Channels.EUlike.Bands[iBand];
+
+        band.txDutyDenom = LMIC.bands[iBand].txpow;
+        band.txPower = LMIC.bands[iBand].txpow;
+        band.lastChannel = LMIC.bands[iBand].lastchnl;
+
+        // don't record tAval from the past, and only record into the future.
+        auto const tDelta = LMIC.bands[iBand].avail - tNow;
+        band.ostimeAvail = tDelta > 0 ? tDelta : 0;
+        }
+
+#elif CFG_LMIC_US_like
+    State.V1.Channels.Header.Tag = State.V1.Channels.Header.kEUlike;
+    State.V1.Channels.Header.Tag = sizeof(State.V1.Channels.USlike);
+
+    State.V1.Channels.USlike.clearAll();
+    for (unsigned ch = 0; ch < State.V1.Channels.USlike.nCh; ++ch)
+        {
+        bool state = ENABLED_CHANNEL(ch);
+        State.V1.Channels.USlike.enable(ch, state);
+        }
+#endif
+	}
+
+#undef FUNCTION
+
+/*
+
+Name:	Arduino_LoRaWAN::SaveSessionState()
+
+Function:
+    Internal: build and save session state
+
+Definition:
+    void Arduino_LoRaWAN::SaveSessionState(
+        void
+        );
+
+Description:
+    This is just a convenience wrapper: first build, then
+    save the session state. The client must have supplied
+    a virtual override for NetSaveSessionState() to actually
+    do the save.
+
+Returns:
+    No explicit result.
+
+Notes:
+    
+
+*/
+
+void Arduino_LoRaWAN::SaveSessionState()
+    {
+    SessionState State;
+
+    this->BuildSessionState(State);
+    if (memcmp(&State, &this->m_savedSessionState, sizeof(State)) != 0)
+        {
+        this->m_savedSessionState = State;
+        this->NetSaveSessionState(State);
+        }
+    }
+
+/*
+
+Name:	Arduino_LoRaWAN::SaveSessionState()
+
+Function:
+    Internal: fetch and apply session state
+
+Definition:
+    bool Arduino_LoRaWAN::RestoreSessionState(
+        void
+        );
+
+Description:
+    This is just a convenience wrapper: first fetch, then
+    apply the session state. The client must have supplied
+    a virtual override for NetSaveSessionState() to actually
+    do the save. The restored state must generally match
+    the configured region, or it will be ignored.
+
+Returns:
+    No explicit result.
+
+Notes:
+    
+
+*/
+
+bool Arduino_LoRaWAN::RestoreSessionState()
+    {
+    SessionState State;
+
+    if (! this->NetGetSessionState(State))
+        return false;
+
+    return this->ApplySessionState(State);
+    }
+
+/*
+
+Name:	Arduino_LoRaWAN::ApplySessionState()
+
+Function:
+    Apply SessionState data to current LMIC session.
+
+Definition:
+    bool Arduino_LoRaWAN::ApplySessionState(
+        Arduino_LoRaWAN::SessionState const &State
+        );
+
+Description:
+    If the contents of the State structure are useful, they are applied
+    to the current LMIC session, to bring things back to the point
+    where the were at moment it was saved.
+
+Returns:
+    `true` if the state could be applied, `false` otherwise.
+
+Notes:
+    
+
+*/
+
+#define FUNCTION "Arduino_LoRaWAN::ApplySessionState"
+
+bool
+Arduino_LoRaWAN::ApplySessionState(
+    const Arduino_LoRaWAN::SessionState &State
+    )
+    {
+    // do not apply the session state unless it rougly matches our configuration.
+    if (State.Header.Tag == kSessionStateTag_V1 && 
+        Arduino_LoRaWAN::Region(State.V1.Region) == this->GetRegion() &&
+        State.V1.Country == uint16_t(this->GetCountryCode())
+        )
+        {
+        auto const tNow = os_getTime();
+
+        // record that we've done it.
+        this->m_savedSessionState = State;
+
+        // set FcntUp, FcntDown, and session state
+        LMIC.datarate   = State.V1.LinkDR;
+
+        // set the uplink and downlink count
+        LMIC.seqnoDn    = State.V1.FCntDown;
+        LMIC.seqnoUp    = State.V1.FCntUp;
+
+        //
+        // TODO(tmm@mcci.com): State.V1.gpsTime can be used to tweak the saved cycle
+        // time and also as a fallback if the system clock is not robust. but right
+        // now we ignore it.
+        //
+
+        // conservatively set the global avail time.
+        LMIC.globalDutyAvail = tNow + State.V1.globalAvail;
+
+        // set the Rx2 frequency
+        LMIC.dn2Freq    = State.V1.Rx2Frequency;
+
+#if !defined(DISABLE_PING)
+        // set the ping frequency
+        LMIC.ping.freq  = State.V1.PingFrequency;
+#endif
+
+        LMIC.adrAckReq = State.V1.LinkIntegrity;
+        LMIC.adrTxPow = State.V1.TxPower;
+        LMIC.upRepeat = State.V1.Redundancy;
+        LMIC.globalDutyRate = State.V1.DutyCycle;
+        LMIC.rx1DrOffset = State.V1.Rx1DRoffset;
+        LMIC.dn2Dr = State.V1.Rx2DataRate;
+        LMIC.rxDelay = State.V1.RxDelay;
+
+#if LMIC_ENABLE_TxParamSetupReq
+        LMIC.txParam = State.V1.TxParam;
+#endif
+#if !defined(DISABLE_BEACONS)
+        LMIC.bcnChnl = State.V1.BeaconChannel;
+#endif
+#if !defined(DISABLE_PING)
+        LMIC.ping.dr = State.V1.PingDr;
+#endif
+        LMIC.dn2Ans = State.V1.MacRxParamAns;
+        LMIC.macDlChannelAns = State.V1.MacDlChannelAns;
+        LMIC.macRxTimingSetupAns = State.V1.MacRxTimingSetupAns;
+
+#if CFG_LMIC_EU_like
+        // don't turn off bits: user can't fool us here.
+        // we can get the immutable channels from the 
+        // channelMap value after reset.
+        auto const resetMap = LMIC.channelMap;
+        auto const & euLike = State.V1.Channels.EUlike;
+        LMIC.channelMap |= euLike.ChannelMap;
+
+        for (unsigned ch = 0; ch < MAX_CHANNELS; ++ch)
+            {
+            if ((resetMap & (decltype(resetMap)(1) << ch)) == 0)
+                {
+                // copy data -- note that the saved band number is encoded
+                LMIC_setupChannel(
+                    ch,
+                    euLike.getFrequency(euLike.UplinkFreq, ch),
+                    euLike.ChannelDrMap[ch],
+                    euLike.getBand(ch)
+                    );
+#if !defined(DISABLE_MCMD_DlChannelReq)
+                LMIC.channelDlFreq[ch] = euLike.getFrequency(euLike.DownlinkFreq, ch);
+#endif
+                }
+            }
+
+        for (unsigned band = 0; band < MAX_BANDS; ++band)
+            {
+            LMIC.bands[band].txcap = euLike.Bands[band].txDutyDenom;
+            LMIC.bands[band].txpow = euLike.Bands[band].txPower;
+            LMIC.bands[band].lastchnl = euLike.Bands[band].lastChannel;
+            // Heuristic; we don't know how long has passed since we saved
+            // this, because we don't currently have GPS time available.
+            // Conservatively reserve time from now. 
+            LMIC.bands[band].avail = tNow + euLike.Bands[band].ostimeAvail;
+            }
+
+#elif CFG_LMIC_US_like
+        // copy the enabled states
+        for (unsigned ch = 0; ch < State.V1.Channels.USlike.nCh; ++ch)
+            {
+            const bool state = State.V1.Channels.USlike.isEnabled(ch);
+
+            if (state)
+                LMIC_enableChannel(ch);
+            else
+                LMIC_disableChannel(ch);
+            }
+#endif
+
+        return true;
+        }
+    else
+        {
+        return false;
+        }
+    }
+
+#undef FUNCTION

--- a/src/lib/arduino_lorawan_sessionstate.cpp
+++ b/src/lib/arduino_lorawan_sessionstate.cpp
@@ -44,7 +44,7 @@ Returns:
 	No explicit result.
 
 Notes:
-	
+
 
 */
 
@@ -167,7 +167,7 @@ Returns:
     No explicit result.
 
 Notes:
-    
+
 
 */
 
@@ -206,7 +206,7 @@ Returns:
     No explicit result.
 
 Notes:
-    
+
 
 */
 
@@ -241,7 +241,7 @@ Returns:
     `true` if the state could be applied, `false` otherwise.
 
 Notes:
-    
+
 
 */
 
@@ -253,7 +253,7 @@ Arduino_LoRaWAN::ApplySessionState(
     )
     {
     // do not apply the session state unless it rougly matches our configuration.
-    if (State.Header.Tag == kSessionStateTag_V1 && 
+    if (State.Header.Tag == kSessionStateTag_V1 &&
         Arduino_LoRaWAN::Region(State.V1.Region) == this->GetRegion() &&
         State.V1.Country == uint16_t(this->GetCountryCode())
         )
@@ -310,7 +310,7 @@ Arduino_LoRaWAN::ApplySessionState(
 
 #if CFG_LMIC_EU_like
         // don't turn off bits: user can't fool us here.
-        // we can get the immutable channels from the 
+        // we can get the immutable channels from the
         // channelMap value after reset.
         auto const resetMap = LMIC.channelMap;
         auto const & euLike = State.V1.Channels.EUlike;
@@ -340,7 +340,7 @@ Arduino_LoRaWAN::ApplySessionState(
             LMIC.bands[band].lastchnl = euLike.Bands[band].lastChannel;
             // Heuristic; we don't know how long has passed since we saved
             // this, because we don't currently have GPS time available.
-            // Conservatively reserve time from now. 
+            // Conservatively reserve time from now.
             LMIC.bands[band].avail = tNow + euLike.Bands[band].ostimeAvail;
             }
 

--- a/src/lib/arduino_lorawan_shutdown.cpp
+++ b/src/lib/arduino_lorawan_shutdown.cpp
@@ -18,10 +18,10 @@ Copyright notice:
 		Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	March 2017
 

--- a/src/lib/chirpstack_eu868_netbeginregioninit.cpp
+++ b/src/lib/chirpstack_eu868_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
     See LICENSE file accompanying this project.
- 
+
 Author:
     Terry Moore, MCCI Corporation	February 2020
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_ChirpStack_eu868::NetBeginRegionInit()
     {
     //
-    // for eu868, we don't need to do any special setup. 
+    // for eu868, we don't need to do any special setup.
     //
     }

--- a/src/lib/chirpstack_in866_netbeginregioninit.cpp
+++ b/src/lib/chirpstack_in866_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
         See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	February 2020
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_ChirpStack_in866::NetBeginRegionInit()
     {
     //
-    // for in866, we don't need to do any special setup. 
+    // for in866, we don't need to do any special setup.
     //
     }

--- a/src/lib/chirpstack_kr920_netbeginregioninit.cpp
+++ b/src/lib/chirpstack_kr920_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
         See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	February 2020
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_ChirpStack_kr920::NetBeginRegionInit()
     {
     //
-    // for kr920, we don't need to do any special setup. 
+    // for kr920, we don't need to do any special setup.
     //
     }

--- a/src/lib/chirpstack_us915_netjoin.cpp
+++ b/src/lib/chirpstack_us915_netjoin.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
     See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	February 2020
 

--- a/src/lib/generic_eu868_netbeginregioninit.cpp
+++ b/src/lib/generic_eu868_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
     See LICENSE file accompanying this project.
- 
+
 Author:
     Terry Moore, MCCI Corporation	February 2020
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_Generic_eu868::NetBeginRegionInit()
     {
     //
-    // for eu868, we don't need to do any special setup. 
+    // for eu868, we don't need to do any special setup.
     //
     }

--- a/src/lib/generic_in866_netbeginregioninit.cpp
+++ b/src/lib/generic_in866_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
         See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	February 2020
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_Generic_in866::NetBeginRegionInit()
     {
     //
-    // for in866, we don't need to do any special setup. 
+    // for in866, we don't need to do any special setup.
     //
     }

--- a/src/lib/generic_kr920_netbeginregioninit.cpp
+++ b/src/lib/generic_kr920_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
         See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	February 2020
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_Generic_kr920::NetBeginRegionInit()
     {
     //
-    // for kr920, we don't need to do any special setup. 
+    // for kr920, we don't need to do any special setup.
     //
     }

--- a/src/lib/generic_us915_netjoin.cpp
+++ b/src/lib/generic_us915_netjoin.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
     See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	February 2020
 

--- a/src/lib/machineq_base_netjoin.cpp
+++ b/src/lib/machineq_base_netjoin.cpp
@@ -18,10 +18,10 @@ Copyright notice:
 		Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	November 2016
 

--- a/src/lib/machineq_us915_netjoin.cpp
+++ b/src/lib/machineq_us915_netjoin.cpp
@@ -18,10 +18,10 @@ Copyright notice:
 		Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	November 2016
 

--- a/src/lib/senra_in866_netbeginregioninit.cpp
+++ b/src/lib/senra_in866_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
         See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	February 2020
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_Senra_in866::NetBeginRegionInit()
     {
     //
-    // for in866, we don't need to do any special setup. 
+    // for in866, we don't need to do any special setup.
     //
     }

--- a/src/lib/swisscom_eu868_netbeginregioninit.cpp
+++ b/src/lib/swisscom_eu868_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
     See LICENSE file accompanying this project.
- 
+
 Author:
     Terry Moore, MCCI Corporation	February 2020
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_Swisscom_eu868::NetBeginRegionInit()
     {
     //
-    // for eu868, we don't need to do any special setup. 
+    // for eu868, we don't need to do any special setup.
     //
     }

--- a/src/lib/ttn_as923_netbeginregioninit.cpp
+++ b/src/lib/ttn_as923_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
         See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	November 2016
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_ttn_as923::NetBeginRegionInit()
     {
     //
-    // for as923, we don't need to do any special setup. 
+    // for as923, we don't need to do any special setup.
     //
     }

--- a/src/lib/ttn_base_netjoin.cpp
+++ b/src/lib/ttn_base_netjoin.cpp
@@ -18,10 +18,10 @@ Copyright notice:
 		Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	November 2016
 

--- a/src/lib/ttn_eu868_netbeginregioninit.cpp
+++ b/src/lib/ttn_eu868_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
         See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	November 2016
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_ttn_eu868::NetBeginRegionInit()
     {
     //
-    // for eu868, we don't need to do any special setup. 
+    // for eu868, we don't need to do any special setup.
     //
     }

--- a/src/lib/ttn_in866_netbeginregioninit.cpp
+++ b/src/lib/ttn_in866_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
         See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	November 2016
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_ttn_in866::NetBeginRegionInit()
     {
     //
-    // for in866, we don't need to do any special setup. 
+    // for in866, we don't need to do any special setup.
     //
     }

--- a/src/lib/ttn_kr920_netbeginregioninit.cpp
+++ b/src/lib/ttn_kr920_netbeginregioninit.cpp
@@ -7,7 +7,7 @@ Function:
 
 Copyright notice:
         See LICENSE file accompanying this project.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	November 2016
 
@@ -42,6 +42,6 @@ Author:
 void Arduino_LoRaWAN_ttn_kr920::NetBeginRegionInit()
     {
     //
-    // for kr920, we don't need to do any special setup. 
+    // for kr920, we don't need to do any special setup.
     //
     }

--- a/src/lib/ttn_us915_netjoin.cpp
+++ b/src/lib/ttn_us915_netjoin.cpp
@@ -18,10 +18,10 @@ Copyright notice:
 		Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	November 2016
 


### PR DESCRIPTION
This patch completely reworks session handling; it's almost complete, except that there is no provision for saving the current state of the channel shuffle pattern. (That's not in the LMIC yet, which is why I overlooked it.) This works pretty well in my testing with US915 and TTN V3. It also works with V2. Needs to be tested with EU, because the channel handling is a lot different and more complicated.