### PR TITLE
Fixes from `-Wall` checks with Catena-Arduino-Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Much more elaborate uses can be found in the MCCI [Catena-Arduino-Platform](http
 
 - Head includes the following changes.
 
+  - Fix `-Wunused-parameter` warnings from gcc. ([#196](https://github.com/mcci-catena/arduino-lorawan/issues/196)). This is v0.9.2-pre3.
   - Apply pre-release version to `library.properties` and `library.json` ([#195](https://github.com/mcci-catena/arduino-lorawan/issues/195)). This is v0.9.2-pre2.
   - Correct error, missing `return true` at end of `Arduino_LoRaWAN::ApplySessionState()`. ([#194])(https://github.com/mcci-catena/arduino-lorawan/issues/194)).
   - Correct error in logging, missing `return true` in `Arduino_LoRaWAN::cEventLog::processSingleEvent()` ([#191](https://github.com/mcci-catena/arduino-lorawan/issues/191)). This is v0.9.2-pre1.

--- a/README.md
+++ b/README.md
@@ -430,7 +430,9 @@ Much more elaborate uses can be found in the MCCI [Catena-Arduino-Platform](http
 
 - Head includes the following changes.
 
-  - Correct error in logging, missing `return true` in `Arduino_LoRaWAN::cEventLog::processSingleEvent()` ([#191](https://github.com/mcci-catena/arduino-lorawan/issues/169)). This is v0.9.2-pre1.
+  - Apply pre-release version to `library.properties` and `library.json` ([#195](https://github.com/mcci-catena/arduino-lorawan/issues/195)). This is v0.9.2-pre2.
+  - Correct error, missing `return true` at end of `Arduino_LoRaWAN::ApplySessionState()`. ([#194])(https://github.com/mcci-catena/arduino-lorawan/issues/194)).
+  - Correct error in logging, missing `return true` in `Arduino_LoRaWAN::cEventLog::processSingleEvent()` ([#191](https://github.com/mcci-catena/arduino-lorawan/issues/191)). This is v0.9.2-pre1.
 
 - v0.9.1 includes the following changes.
 

--- a/library.json
+++ b/library.json
@@ -31,7 +31,7 @@
       "authors": ["Terry Moore <tmm@mcci.com>"]
     }
   ],
-  "version": "0.9.1",
+  "version": "0.9.2-pre1",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.json
+++ b/library.json
@@ -31,7 +31,7 @@
       "authors": ["Terry Moore <tmm@mcci.com>"]
     }
   ],
-  "version": "0.9.2-pre2",
+  "version": "0.9.2-pre3",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.json
+++ b/library.json
@@ -31,7 +31,7 @@
       "authors": ["Terry Moore <tmm@mcci.com>"]
     }
   ],
-  "version": "0.9.2-pre1",
+  "version": "0.9.2-pre2",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MCCI Arduino LoRaWAN Library
-version=0.9.2-pre2
+version=0.9.2-pre3
 author=Terry Moore, ChaeHee Won
 maintainer=Terry Moore <tmm@mcci.com>
 sentence=High-level library for LoRaWAN-based Arduino end-devices.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MCCI Arduino LoRaWAN Library
-version=0.9.2-pre1
+version=0.9.2-pre2
 author=Terry Moore, ChaeHee Won
 maintainer=Terry Moore <tmm@mcci.com>
 sentence=High-level library for LoRaWAN-based Arduino end-devices.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MCCI Arduino LoRaWAN Library
-version=0.9.1
+version=0.9.2-pre1
 author=Terry Moore, ChaeHee Won
 maintainer=Terry Moore <tmm@mcci.com>
 sentence=High-level library for LoRaWAN-based Arduino end-devices.

--- a/src/Arduino_LoRaWAN.h
+++ b/src/Arduino_LoRaWAN.h
@@ -34,7 +34,7 @@ Author:
 ///     \ref ARDUINO_LORAWAN_VERSION_COMPARE_LT() to compare relative versions.
 ///
 #define ARDUINO_LORAWAN_VERSION \
-        ARDUINO_LORAWAN_VERSION_CALC(0, 9, 2, 1) /* v0.9.2-pre1 */
+        ARDUINO_LORAWAN_VERSION_CALC(0, 9, 2, 2) /* v0.9.2-pre2 */
 
 #define ARDUINO_LORAWAN_VERSION_GET_MAJOR(v)    \
         (((v) >> 24u) & 0xFFu)

--- a/src/Arduino_LoRaWAN.h
+++ b/src/Arduino_LoRaWAN.h
@@ -34,7 +34,7 @@ Author:
 ///     \ref ARDUINO_LORAWAN_VERSION_COMPARE_LT() to compare relative versions.
 ///
 #define ARDUINO_LORAWAN_VERSION \
-        ARDUINO_LORAWAN_VERSION_CALC(0, 9, 2, 2) /* v0.9.2-pre2 */
+        ARDUINO_LORAWAN_VERSION_CALC(0, 9, 2, 3) /* v0.9.2-pre3 */
 
 #define ARDUINO_LORAWAN_VERSION_GET_MAJOR(v)    \
         (((v) >> 24u) & 0xFFu)
@@ -844,6 +844,10 @@ protected:
                         size_t nExtraSessionInfo
                         )
                 {
+                MCCIADK_API_PARAMETER(SessionInfo);
+                MCCIADK_API_PARAMETER(pExtraSessionInfo);
+                MCCIADK_API_PARAMETER(nExtraSessionInfo);
+
                 // default: do nothing.
                 }
 
@@ -854,6 +858,8 @@ protected:
                 SessionState &State
                 )
                 {
+                MCCIADK_API_PARAMETER(State);
+
                 // default: not implemented.
                 return false;
                 }
@@ -866,6 +872,8 @@ protected:
                 const SessionState &State
                 )
                 {
+                MCCIADK_API_PARAMETER(State);
+
                 // default: do nothing.
                 }
 

--- a/src/lib/arduino_lorawan_sessionstate.cpp
+++ b/src/lib/arduino_lorawan_sessionstate.cpp
@@ -411,6 +411,7 @@ Arduino_LoRaWAN::ApplySessionState(
             LMIC_disableChannel(ch);
         }
 #endif
+    return true;
     }
 
 #undef FUNCTION


### PR DESCRIPTION
#194: Missing return value in `Arduino_LoRaWAN::ApplySessionState()`.
#195: Get version numbers in sync between `library.properties`, `library.json` and `Arduino_LoRaWAN.h`.
#196: Fix `-Wunused-parameter` warnings

Version set to v0.9.2-pre2.