### PR TITLE
Add return statement on Arduino_LoRaWAN::setFrequency

### DIFF
--- a/src/Arduino_LoRaWAN.h
+++ b/src/Arduino_LoRaWAN.h
@@ -368,6 +368,8 @@ public:
                         chPtr[0] = uint8_t(reducedFreq >> 16);
                         chPtr[1] = uint8_t(reducedFreq >> 8);
                         chPtr[2] = uint8_t(reducedFreq);
+                        
+                        return true;
                         }
 
                 /// \brief clear all entries in the channel table.


### PR DESCRIPTION
Missing return statement on Arduino_LoRaWAN::setFrequency - causes compile errors. Could be related to an earlier issue I raised? https://github.com/mcci-catena/arduino-lorawan/issues/181